### PR TITLE
Unblock Ruby upgrades

### DIFF
--- a/heroku-log-parser.gemspec
+++ b/heroku-log-parser.gemspec
@@ -23,30 +23,4 @@ Gem::Specification.new do |s|
   end
 
   s.required_ruby_version = ">= 1.8.7"
-
-  # s.add_dependency('activerecord', '>= 3.0.0')
-  # s.add_dependency('activemodel', '>= 3.0.0')
-  # s.add_dependency('activesupport', '>= 3.0.0')
-  # s.add_dependency('cocaine', '~> 0.4.0')
-  # s.add_dependency('mime-types')
-
-  # s.add_development_dependency('shoulda')
-  # s.add_development_dependency('appraisal')
-  # s.add_development_dependency('mocha')
-  # s.add_development_dependency('aws-sdk', '>= 1.2.0')
-  # s.add_development_dependency('bourne')
-  # s.add_development_dependency('sqlite3', '~> 1.3.4')
-  # s.add_development_dependency('cucumber', '~> 1.2.1')
-  # s.add_development_dependency('aruba')
-  # s.add_development_dependency('nokogiri')
-  # s.add_development_dependency('capybara')
-  # s.add_development_dependency('bundler')
-  # s.add_development_dependency('cocaine', '~> 0.2')
-  # s.add_development_dependency('fog', '>= 1.4.0', "< 1.7.0")
-  # s.add_development_dependency('pry')
-  # s.add_development_dependency('launchy')
-  # s.add_development_dependency('rake')
-  # s.add_development_dependency('fakeweb')
-  # s.add_development_dependency('railties')
-  # s.add_development_dependency('actionmailer')
 end

--- a/heroku-log-parser.gemspec
+++ b/heroku-log-parser.gemspec
@@ -18,9 +18,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  if File.exists?('UPGRADING')
-    s.post_install_message = File.read("UPGRADING")
-  end
-
   s.required_ruby_version = ">= 1.8.7"
 end


### PR DESCRIPTION
## Highlights
- resolves underlying cause of https://3.basecamp.com/3653596/buckets/24245485/card_tables/cards/7409921267 Dependabot failure (removal of deprecated `File.exists?` usage)
- https://bugs.ruby-lang.org/issues/17391
- https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2

## Discussion
I've forked the gem to get us over this hurdle. Once merged I'll amend https://github.com/thelookoutway/dataloader_app_logs/blob/main/Gemfile.

We'll need to return and refactor dataloader_app_logs - this approach is probably not sustainable.