### PR TITLE
Bump rake from 10.4.2 to 13.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    heroku-log-parser (0.2.2)
+    heroku-log-parser (0.4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.4.2)
+    rake (13.2.1)
 
 PLATFORMS
   ruby
@@ -16,4 +16,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.6
+   2.5.11


### PR DESCRIPTION
- `bundle update rake`
- `rake test` passes

## Highlights
- resolves https://github.com/thelookoutway/heroku-log-parser/security/dependabot/1
- Vanta alert brought it to my attention